### PR TITLE
Riferimenti pdq

### DIFF
--- a/rtb/piano-di-qualifica/src/introduzione.tex
+++ b/rtb/piano-di-qualifica/src/introduzione.tex
@@ -48,5 +48,5 @@ La presenza di un termine all’interno del glossario viene indicata applicando 
     \url{} %aggiungere link a glossario
 \end{itemize}
 
-Tutti i riferimenti (normativi e informativi) a risorse web soggette a variazione sono stati consultati il 2024/02/22.
+Tutti i riferimenti (normativi e informativi) a risorse web soggette a variazione sono stati consultati il 2024/04/03.
 

--- a/rtb/piano-di-qualifica/src/introduzione.tex
+++ b/rtb/piano-di-qualifica/src/introduzione.tex
@@ -44,6 +44,8 @@ La presenza di un termine all’interno del glossario viene indicata applicando 
     \url{https://www.math.unipd.it/~tullio/IS-1/2023/Dispense/T7.pdf}
     \item Qualità di processo:\\
     \url{https://www.math.unipd.it/~tullio/IS-1/2023/Dispense/T8.pdf}
+    \item Verifica e validazione: \\
+    \url{https://www.math.unipd.it/~tullio/IS-1/2023/Dispense/T9.pdf}
     \item ISO/IEC 9126:2001: \\
     \url{https://www.iso.org/standard/35733.html}
     \item Glossario: \\

--- a/rtb/piano-di-qualifica/src/introduzione.tex
+++ b/rtb/piano-di-qualifica/src/introduzione.tex
@@ -45,7 +45,7 @@ La presenza di un termine all’interno del glossario viene indicata applicando 
     \item Qualità di processo:\\
     \url{https://www.math.unipd.it/~tullio/IS-1/2023/Dispense/T8.pdf}
     \item Glossario: \\
-    \url{} %aggiungere link a glossario
+    \url{https://github.com/SWEet16-SWE-Group/docs/blob/main/RTB/Glossario.pdf} 
 \end{itemize}
 
 Tutti i riferimenti (normativi e informativi) a risorse web soggette a variazione sono stati consultati il 2024/04/03.

--- a/rtb/piano-di-qualifica/src/introduzione.tex
+++ b/rtb/piano-di-qualifica/src/introduzione.tex
@@ -48,6 +48,8 @@ La presenza di un termine all’interno del glossario viene indicata applicando 
     \url{https://www.math.unipd.it/~tullio/IS-1/2023/Dispense/T9.pdf}
     \item Verifica e validazione, analisi statica:\\
     \url{https://www.math.unipd.it/~tullio/IS-1/2023/Dispense/T10.pdf}
+    \item Verifica e validazione, analisi dinamica (aka testing): \\
+    \url{https://www.math.unipd.it/~tullio/IS-1/2023/Dispense/T11.pdf}
     \item ISO/IEC 9126:2001: \\
     \url{https://www.iso.org/standard/35733.html}
     \item Indice di Gulpease: \\

--- a/rtb/piano-di-qualifica/src/introduzione.tex
+++ b/rtb/piano-di-qualifica/src/introduzione.tex
@@ -48,6 +48,8 @@ La presenza di un termine all’interno del glossario viene indicata applicando 
     \url{https://www.math.unipd.it/~tullio/IS-1/2023/Dispense/T9.pdf}
     \item ISO/IEC 9126:2001: \\
     \url{https://www.iso.org/standard/35733.html}
+    \item Indice di Gulpease: \\
+    \url{https://it.wikipedia.org/wiki/Indice_Gulpease}
     \item Glossario: \\
     \url{https://github.com/SWEet16-SWE-Group/docs/blob/main/RTB/Glossario.pdf} 
 \end{itemize}

--- a/rtb/piano-di-qualifica/src/introduzione.tex
+++ b/rtb/piano-di-qualifica/src/introduzione.tex
@@ -46,6 +46,8 @@ La presenza di un termine all’interno del glossario viene indicata applicando 
     \url{https://www.math.unipd.it/~tullio/IS-1/2023/Dispense/T8.pdf}
     \item Verifica e validazione: \\
     \url{https://www.math.unipd.it/~tullio/IS-1/2023/Dispense/T9.pdf}
+    \item Verifica e validazione, analisi statica:\\
+    \url{https://www.math.unipd.it/~tullio/IS-1/2023/Dispense/T10.pdf}
     \item ISO/IEC 9126:2001: \\
     \url{https://www.iso.org/standard/35733.html}
     \item Indice di Gulpease: \\

--- a/rtb/piano-di-qualifica/src/introduzione.tex
+++ b/rtb/piano-di-qualifica/src/introduzione.tex
@@ -44,6 +44,8 @@ La presenza di un termine all’interno del glossario viene indicata applicando 
     \url{https://www.math.unipd.it/~tullio/IS-1/2023/Dispense/T7.pdf}
     \item Qualità di processo:\\
     \url{https://www.math.unipd.it/~tullio/IS-1/2023/Dispense/T8.pdf}
+    \item ISO/IEC 9126:2001: \\
+    \url{https://www.iso.org/standard/35733.html}
     \item Glossario: \\
     \url{https://github.com/SWEet16-SWE-Group/docs/blob/main/RTB/Glossario.pdf} 
 \end{itemize}


### PR DESCRIPTION
close #212 

Il glossario a mio parere è nel luogo sbagliato nella repo, dovrebbe stare all'interno della cartella `/RTB/Documentazione Esterna`, ora invece è dentro a `/RTB` . @bzn0u95quudr7jutfjap 